### PR TITLE
Smooth scroll fix

### DIFF
--- a/src/components/blog/Markdown.js
+++ b/src/components/blog/Markdown.js
@@ -19,16 +19,6 @@ export const Code = props => {
   }
 }
 
-export const Tweet = ({ id }) => {
-  if (typeof window !== 'undefined') {
-    const { TwitterTweetEmbed } = require('react-twitter-embed')
-
-    return <TwitterTweetEmbed tweetId={id} />
-  }
-
-  return null
-}
-
 export const Codesandbox = ({ height = '600px', id, view = 'split' }) => (
   <iframe
     src={`https://codesandbox.io/embed/${id}?verticallayout=1&view=${view}`}

--- a/src/components/blog/Runkit.js
+++ b/src/components/blog/Runkit.js
@@ -48,7 +48,7 @@ export class RunkitProvider extends React.Component {
   }
 }
 
-// TODO add some SVG that looks like code
+// TODO add some SVG that looks like code?
 const CodePlaceholder = styled.div`
   height: ${props => props.height || '200px'};
   width: 100%;

--- a/src/components/blog/Runkit.js
+++ b/src/components/blog/Runkit.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Helmet from 'react-helmet'
 import Embed from 'react-runkit'
+import styled from 'styled-components'
 
 const RunkitContext = React.createContext()
 
@@ -47,16 +48,27 @@ export class RunkitProvider extends React.Component {
   }
 }
 
-export const EmbedRunkit = props => (
+const CodePlaceholder = styled.div`
+  height: ${props => props.height || '200px'};
+  width: 100%;
+`
+
+export const EmbedRunkit = ({ children, ...rest }) => (
   <RunkitContext.Consumer>
     {({ loaded, load, loadRunkit }) => {
       if (loaded) {
-        return <Embed {...props} />
+        return <Embed {...rest} />
       }
       if (!load) {
         loadRunkit()
       }
-      return null
+      let height
+      if (Array.isArray(children) && children[0]) {
+        const numberOfLines = children[0].split(/\r\n|\r|\n/).length
+        height = `${numberOfLines * 25}px`
+      }
+
+      return <CodePlaceholder height={height} />
     }}
   </RunkitContext.Consumer>
 )

--- a/src/components/blog/Runkit.js
+++ b/src/components/blog/Runkit.js
@@ -63,7 +63,7 @@ export const EmbedRunkit = ({ children, ...rest }) => (
       if (!load) {
         loadRunkit()
       }
-      let height
+      let height = '200px'
       if (Array.isArray(children) && children[0]) {
         const numberOfLines = children[0].split(/\r\n|\r|\n/).length
         height = `${numberOfLines * 25}px`

--- a/src/components/blog/Runkit.js
+++ b/src/components/blog/Runkit.js
@@ -48,6 +48,7 @@ export class RunkitProvider extends React.Component {
   }
 }
 
+// TODO add some SVG that looks like code
 const CodePlaceholder = styled.div`
   height: ${props => props.height || '200px'};
   width: 100%;

--- a/src/components/blog/Tweet.js
+++ b/src/components/blog/Tweet.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import styled from 'styled-components'
+
+// TODO add some SVG that looks like a tweet?
+const TweetPlaceholder = styled.div`
+  height: ${props => props.height || '200px'};
+  width: 100%;
+`
+
+const Tweet = ({ id, placeholderHeight }) => {
+  if (typeof window !== 'undefined') {
+    const { TwitterTweetEmbed } = require('react-twitter-embed')
+
+    return <TwitterTweetEmbed tweetId={id} />
+  }
+
+  return <TweetPlaceholder height={placeholderHeight} />
+}
+
+export default Tweet

--- a/src/components/elements/withLazyLoad.js
+++ b/src/components/elements/withLazyLoad.js
@@ -4,11 +4,21 @@ import LazyLoad from 'react-lazyload'
 const withLazyLoad = ({
   defaultConfig = {},
   lazyLoadByDefault = true,
-} = {}) => Component => ({ lazyLoad = lazyLoadByDefault, ...rest }) => {
+} = {}) => Component => ({
+  lazyLoad = lazyLoadByDefault,
+  placeholderHeight = '400px',
+  ...rest
+}) => {
   const element = <Component {...rest} />
   const lazyLoadConfig =
     lazyLoad === true ? defaultConfig : { ...defaultConfig, ...lazyLoad }
-  return lazyLoad ? <LazyLoad {...lazyLoadConfig}>{element}</LazyLoad> : element
+  return lazyLoad ? (
+    <LazyLoad height={placeholderHeight} {...lazyLoadConfig}>
+      {element}
+    </LazyLoad>
+  ) : (
+    element
+  )
 }
 
 export default withLazyLoad

--- a/src/components/navigation/index.js
+++ b/src/components/navigation/index.js
@@ -1,4 +1,9 @@
-import Link, { LinkScroll, DEFAULT_SCROLL_OFFSET, ANCHOR_STYLE } from './Link'
+import Link, {
+  LinkScroll,
+  DEFAULT_SCROLL_OFFSET,
+  ANCHOR_STYLE,
+  DEFAULT_SCROLL_DURATION,
+} from './Link'
 import Breadcrumb from './Breadcrumb'
 import Menu from './menu'
 import Tabs, {
@@ -14,6 +19,7 @@ export {
   LinkScroll,
   ANCHOR_STYLE,
   DEFAULT_SCROLL_OFFSET,
+  DEFAULT_SCROLL_DURATION,
   Breadcrumb,
   Menu,
   Tabs,

--- a/src/config/images.js
+++ b/src/config/images.js
@@ -66,7 +66,7 @@ export const EVA =
   'https://firebasestorage.googleapis.com/v0/b/reactjsacademy-react.appspot.com/o/team%2Feva.jpg?alt=media'
 export const ROY =
   'https://firebasestorage.googleapis.com/v0/b/reactjsacademy-react.appspot.com/o/team%2Froy.jpg?alt=media'
-export const DAVID = 
+export const DAVID =
   'https://firebasestorage.googleapis.com/v0/b/reactjsacademy-react.appspot.com/o/team%2Fdavid.jpg?alt=media'
 
 // Tesimonials

--- a/src/pages/blog/unit-testing-fundamentals-explained-using-javascript.md
+++ b/src/pages/blog/unit-testing-fundamentals-explained-using-javascript.md
@@ -92,7 +92,7 @@ Black-box testing leads to less fragile tests. If you change the implementation 
 
 Have you heard the mantra “do it, then do it right, then do it better”?
 
-<tweet id="314785735171518464"></tweet>
+<tweet id="314785735171518464" placeholder-height="250px"></tweet>
 
 If you write tests that are likely to be refactored everytime the code it tests is refactored, then it’s likely you are not going to refactor your code that often. Meaning you are likely to just “do it”. I don’t know about you, but most developers I know, including myself, don’t “do it right” in the first iteration. A senior developer will plan for future refactoring.
 
@@ -122,7 +122,7 @@ The problem they often find is that it doesn’t quite look like the code they w
 Real world code is made of many units, not just one. Those units might have dependencies between each other.
 Real world code has side-effects. I/O operations are side-effects. Therefore all applications have side effects by nature. Let me get philosophical, if a program has no side-effects at all, does the program exist if you can’t see or communicate with it? If a tree falls in a forest with no side-effects… did it fall?
 
-!["Apps with no side-effects?"](https://firebasestorage.googleapis.com/v0/b/reactjsacademy-react.appspot.com/o/blog%20post%20images%2Fside-effect.png?alt=media)
+<img placeholder-height="558px" src="https://firebasestorage.googleapis.com/v0/b/reactjsacademy-react.appspot.com/o/blog%20post%20images%2Fside-effect.png?alt=media" alt="Apps with no side-effects?"></img>
 
 The issue that I observe is that the code they write is:
 Too complex. It has too much unpredictable code or predictable and unpredictable code is not clearly separated.

--- a/src/pages/blog/unit-testing-fundamentals-explained-using-javascript.md
+++ b/src/pages/blog/unit-testing-fundamentals-explained-using-javascript.md
@@ -92,7 +92,7 @@ Black-box testing leads to less fragile tests. If you change the implementation 
 
 Have you heard the mantra “do it, then do it right, then do it better”?
 
-<tweet id="314785735171518464" placeholder-height="250px"></tweet>
+<tweet id="314785735171518464" placeholder-height="188px"></tweet>
 
 If you write tests that are likely to be refactored everytime the code it tests is refactored, then it’s likely you are not going to refactor your code that often. Meaning you are likely to just “do it”. I don’t know about you, but most developers I know, including myself, don’t “do it right” in the first iteration. A senior developer will plan for future refactoring.
 
@@ -122,7 +122,7 @@ The problem they often find is that it doesn’t quite look like the code they w
 Real world code is made of many units, not just one. Those units might have dependencies between each other.
 Real world code has side-effects. I/O operations are side-effects. Therefore all applications have side effects by nature. Let me get philosophical, if a program has no side-effects at all, does the program exist if you can’t see or communicate with it? If a tree falls in a forest with no side-effects… did it fall?
 
-<img placeholder-height="558px" src="https://firebasestorage.googleapis.com/v0/b/reactjsacademy-react.appspot.com/o/blog%20post%20images%2Fside-effect.png?alt=media" alt="Apps with no side-effects?"></img>
+<img placeholder-height="334px" src="https://firebasestorage.googleapis.com/v0/b/reactjsacademy-react.appspot.com/o/blog%20post%20images%2Fside-effect.png?alt=media" alt="Apps with no side-effects?"></img>
 
 The issue that I observe is that the code they write is:
 Too complex. It has too much unpredictable code or predictable and unpredictable code is not clearly separated.

--- a/src/pages/curriculum.js
+++ b/src/pages/curriculum.js
@@ -10,6 +10,7 @@ import LinkButton from '../components/buttons/LinkButton'
 import {
   Link,
   DEFAULT_SCROLL_OFFSET,
+  DEFAULT_SCROLL_DURATION,
   Tabs,
   TabList,
   TabItem,
@@ -56,7 +57,7 @@ class Curriculum extends React.Component {
         () =>
           scroller.scrollTo(defaultSection || 'curriculum', {
             smooth: true,
-            duration: 500,
+            duration: DEFAULT_SCROLL_DURATION,
             offset: DEFAULT_SCROLL_OFFSET,
           }),
         200

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -13,12 +13,8 @@ import { Image } from '../components/elements'
 import ContactForm from '../components/form/Contact'
 import { Card } from '../components/elements'
 import { blogAuthors } from '../config/data'
-import {
-  Code,
-  Tweet,
-  Blockquote,
-  Codesandbox,
-} from '../components/blog/Markdown'
+import { Code, Blockquote, Codesandbox } from '../components/blog/Markdown'
+import Tweet from '../components/blog/Tweet'
 import ShareButtons from '../components/blog/ShareButtons'
 
 export const formatPostTitle = title => title.replace('<br/>', ' ')


### PR DESCRIPTION
This PR:
- Fixes smooth scrolingl between pages, an example from https://reactjs.academy/react-redux-training-amsterdam/ when clicking on Roy it navigates to the about us but the smooth scroll doesn't work.
- When navigating to an anchor from a different page, example navigating from a blog post to another post#some-anchor by clicking on a link the position of the scroll is not correct even after fixing the smooth scrolling. The reason is some assets are loaded async like tweets or images and the scroll is set based on the initial page height. When the async assets are loaded after the page is rendered the height of the page changes and then the scroll gets in a wrong position This PR solves this issue by adding a placeholder height to those assets that correspond to the height of the assets that will be loaded