### PR TITLE
GraphQL landing page on RJSA

### DIFF
--- a/src/components/curriculum/CurriculumGraphQL.js
+++ b/src/components/curriculum/CurriculumGraphQL.js
@@ -1,0 +1,109 @@
+import React from 'react'
+import Link from '../navigation/Link'
+import { H2Ref } from '../text'
+import Section, { curriedToggleNavigateTo } from './CurriculumSection'
+import { Col, Row } from '../layout/Grid'
+import GraphQLDayOneSessions from './sessions/GraphQLDayOneSessions'
+import GraphQLDayTwoSessions from './sessions/GraphQLDayTwoSessions'
+import GraphQLDayThreeSessions from './sessions/GraphQLDayThreeSessions'
+import GraphQLDayFourSessions from './sessions/GraphQLDayFourSessions'
+import GraphQLDayFiveSessions from './sessions/GraphQLDayFiveSessions'
+
+import { LinkButton } from '../buttons'
+import SectionCTA from './SectionCTA'
+import { GRAPHQL_BOOTCAMP } from '../../config/data'
+import selectCurriculumLayout, { LIST_TWO_COL } from './selectCurriculumLayout'
+
+const CurriculumGraphQL = ({
+  showTitle = true,
+  layout,
+  enableToggle,
+  isOpen,
+  toggleNavigateTo = `/curriculum?tab=${GRAPHQL_BOOTCAMP}`,
+  showLinkToCurriculum = false,
+}) => {
+  const toggleNavigateToSection = curriedToggleNavigateTo(toggleNavigateTo)
+  const commonProps = {
+    enableToggle,
+    toggleNavigateTo: toggleNavigateToSection,
+    type: GRAPHQL_BOOTCAMP,
+    isOpen,
+  }
+  const firstHalf = (
+    <React.Fragment>
+      <Section
+        {...commonProps}
+        title="GraphQL API Fundamentals"
+        name="day1"
+        subTitle="Nodejs and GraphQL fundamentals"
+      >
+        <GraphQLDayOneSessions />
+      </Section>
+      <Section
+        {...commonProps}
+        title="Day 2: Advanced GraphQL API"
+        name="day2"
+        subTitle="Implement a GraphQL API, Advanced Schema, Performance"
+      >
+        <GraphQLDayTwoSessions />
+      </Section>
+      <Section
+        {...commonProps}
+        title="Day 3: Real-world GraphQL API"
+        name="day3"
+        subTitle="Data sources and GraphQL in production considerations"
+      >
+        <GraphQLDayThreeSessions />
+      </Section>
+    </React.Fragment>
+  )
+  const secondHalf = (
+    <React.Fragment>
+      <Section
+        {...commonProps}
+        title="Day 5: Production-ready GraphQL & React"
+        name="day5"
+        subTitle="Testing GraphQL, replacing redux with GraphQL and production tooling"
+      >
+        <GraphQLDayFiveSessions />
+      </Section>
+      <Section
+        {...commonProps}
+        title="Day 4: GraphQL & React"
+        name="day4"
+        subTitle="Apollo Client, Advanced Queries and mutations"
+      >
+        <GraphQLDayFourSessions />
+      </Section>
+      {showLinkToCurriculum ? (
+        <SectionCTA>
+          <LinkButton secondary to="/curriculum">
+            Full curriculum >>
+          </LinkButton>
+        </SectionCTA>
+      ) : null}
+    </React.Fragment>
+  )
+
+  return (
+    <React.Fragment>
+      {showTitle ? (
+        <Row>
+          <Col lgOffset={layout != LIST_TWO_COL && 1}>
+            <H2Ref>
+              GraphQL Bootcamp Curriculum{' '}
+              <Link to="#curriculum" name="curriculum">
+                #
+              </Link>
+            </H2Ref>
+          </Col>
+        </Row>
+      ) : (
+        ''
+      )}
+      {selectCurriculumLayout({ firstHalf, secondHalf, layout })}
+    </React.Fragment>
+  )
+}
+
+export default CurriculumGraphQL

--- a/src/components/curriculum/CurriculumGraphQL.js
+++ b/src/components/curriculum/CurriculumGraphQL.js
@@ -23,10 +23,11 @@ const CurriculumGraphQL = ({
   showLinkToCurriculum = false,
 }) => {
   const toggleNavigateToSection = curriedToggleNavigateTo(toggleNavigateTo)
+  const type = GRAPHQL_BOOTCAMP
   const commonProps = {
     enableToggle,
     toggleNavigateTo: toggleNavigateToSection,
-    type: GRAPHQL_BOOTCAMP,
+    type,
     isOpen,
   }
   const firstHalf = (
@@ -101,7 +102,7 @@ const CurriculumGraphQL = ({
       ) : (
         ''
       )}
-      {selectCurriculumLayout({ firstHalf, secondHalf, layout })}
+      {selectCurriculumLayout({ firstHalf, secondHalf, layout, type })}
     </React.Fragment>
   )
 }

--- a/src/components/curriculum/index.js
+++ b/src/components/curriculum/index.js
@@ -6,6 +6,7 @@ import MarketingCard from './MarketingCard'
 import CurriculumAdvancedReact from './CurriculumAdvancedReact'
 import Curriculum1DayAdvancedReactRedux from './Curriculum1DayAdvancedReactRedux'
 import CurriculumCorpTraining from './CurriculumCorpTraining'
+import CurriculumGraphQL from './CurriculumGraphQL'
 
 export {
   CurriculumBootcamp,
@@ -16,4 +17,5 @@ export {
   CurriculumAdvancedReact,
   Curriculum1DayAdvancedReactRedux,
   CurriculumCorpTraining,
+  CurriculumGraphQL,
 }

--- a/src/components/curriculum/sessions/GraphQLDayFiveSessions.js
+++ b/src/components/curriculum/sessions/GraphQLDayFiveSessions.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import Ul, { Li } from '../../layout/Ul'
+import Session from './Session'
+
+const DayFiveSessions = ({ title }) => (
+  <Session title={title}>
+    <Ul>
+      <Li>
+        Testing GraphQL queries and mutations:
+        <Ul>
+          <Li>Integration tests</Li>
+          <Li>Mocking</Li>
+        </Ul>
+      </Li>
+      <Li>
+        Real time:
+        <Ul>
+          <Li>Polling</Li>
+          <Li>GraphQL subscriptions</Li>
+        </Ul>
+      </Li>
+      <Li>
+        Replacing Redux with GraphQL
+        <Ul>
+          <Li>Strategy and best practices</Li>
+          <Li>Apollo Local state vs React Context</Li>
+        </Ul>
+      </Li>
+      <Li>GraphQL Tooling to speed up front-end development</Li>
+    </Ul>
+  </Session>
+)
+
+export default DayFiveSessions

--- a/src/components/curriculum/sessions/GraphQLDayFourSessions.js
+++ b/src/components/curriculum/sessions/GraphQLDayFourSessions.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import Ul, { Li } from '../../layout/Ul'
+import Session from './Session'
+
+const DayFourSessions = ({ title }) => (
+  <Session title={title}>
+    <Ul>
+      <Li>
+        Apollo Client fundamentals
+        <Ul>
+          <Li>Apollo Client</Li>
+          <Li>Query and Mutation principles</Li>
+        </Ul>
+      </Li>
+      <Li>
+        Advanced GraphQL Queries
+        <Ul>
+          <Li>Query co-location</Li>
+          <Li>Fragment composition</Li>
+          <Li>Extending the Schema on the client</Li>
+        </Ul>
+      </Li>
+      <Li>
+        Advanced Mutations:
+        <Ul>
+          <Li>Error handling</Li>
+          <Li>Optimistic UI</Li>
+          <Li>Updating cached queries</Li>
+        </Ul>
+      </Li>
+      <Li>
+        Performance
+        <Ul>
+          <Li>Prefetching data</Li>
+          <Li>Query batching</Li>
+        </Ul>
+      </Li>
+    </Ul>
+  </Session>
+)
+
+export default DayFourSessions

--- a/src/components/curriculum/sessions/GraphQLDayOneSessions.js
+++ b/src/components/curriculum/sessions/GraphQLDayOneSessions.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import Ul, { Li } from '../../layout/Ul'
+import Session from './Session'
+
+const DayOneSessions = ({ title }) => (
+  <Session title={title}>
+    <Ul>
+      <Li>
+        Nodejs
+        <Ul>
+          <Li>Foundation: npm and Node architecture</Li>
+          <Li>ExpressJS: Server, middlewares, and routing</Li>
+        </Ul>
+      </Li>
+      <Li>
+        Thinking in GraphQL
+        <Ul>
+          <Li>Switching from REST to GraphQL</Li>
+          <Li>
+            Schema
+            <Ul>
+              <Li>Types</Li>
+              <Li>Fields</Li>
+              <Li>Queries</Li>
+              <Li>Mutations</Li>
+            </Ul>
+          </Li>
+        </Ul>
+      </Li>
+    </Ul>
+  </Session>
+)
+
+export default DayOneSessions

--- a/src/components/curriculum/sessions/GraphQLDayThreeSessions.js
+++ b/src/components/curriculum/sessions/GraphQLDayThreeSessions.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import Ul, { Li } from '../../layout/Ul'
+import Session from './Session'
+
+const DayThreeSessions = ({ title }) => (
+  <Session title={title}>
+    <Ul>
+      <Li>
+        Data sources
+        <Ul>
+          <Li>Wrapping existent REST APIs & microservices with GraphQL</Li>
+          <Li>
+            MongoDB
+            <Ul>
+              <Li>Thinking in Documents</Li>
+              <Li>Using MongoDB and GraphQL</Li>
+            </Ul>
+          </Li>
+        </Ul>
+      </Li>
+      <Li>
+        GraphQL in production
+        <Ul>
+          <Li>Monitoring</Li>
+          <Li>Logging</Li>
+          <Li>Error Handling</Li>
+        </Ul>
+      </Li>
+    </Ul>
+  </Session>
+)
+
+export default DayThreeSessions

--- a/src/components/curriculum/sessions/GraphQLDayTwoSessions.js
+++ b/src/components/curriculum/sessions/GraphQLDayTwoSessions.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import Ul, { Li } from '../../layout/Ul'
+import Session from './Session'
+
+const DayTwoSessions = ({ title }) => (
+  <Session title={title}>
+    <Ul>
+      <Li>Recap project, build a GraphQL API from scratch</Li>
+      <Li>
+        Advanced schema
+        <Ul>
+          <Li>Unions</Li>
+          <Li>Type extensions</Li>
+          <Li>Fragments</Li>
+          <Li>Schema modularity to avoid a monolithic schema</Li>
+          <Li>Publishing and registering the schema</Li>
+        </Ul>
+      </Li>
+      <Li>
+        Performance
+        <Ul>
+          <Li>Data Loaders</Li>
+          <Li>Query batching</Li>
+          <Li>Cache backend</Li>
+          <Li>Persisted queries</Li>
+        </Ul>
+      </Li>
+    </Ul>
+  </Session>
+)
+
+export default DayTwoSessions

--- a/src/components/elements/Alert.js
+++ b/src/components/elements/Alert.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
-import { LIGHT_RED, FONT_FAMILY } from '../../config/styles'
+import { PINK, FONT_FAMILY } from '../../config/styles'
 
 const Alert = styled.div`
   ${FONT_FAMILY};
   ${props =>
-    props.danger ? `background-color: ${LIGHT_RED};` : null} padding: 18px 9px;
+    props.danger ? `background-color: ${PINK};` : null} padding: 18px 9px;
   margin: 9px 0;
 `
 

--- a/src/components/elements/Feedback.js
+++ b/src/components/elements/Feedback.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { LIGHT_RED, FONT_FAMILY } from '../../config/styles'
+import { PINK, FONT_FAMILY } from '../../config/styles'
 import Link from '../navigation/Link'
 import { QuestionMarkIcon } from '../icons'
 
@@ -9,7 +9,7 @@ const StyledFeedback = styled.div`
   a {
     margin-left: 4px;
   }
-  border: 2px dashed ${LIGHT_RED};
+  border: 2px dashed ${PINK};
   padding: 1rem;
   margin: 1rem 0;
   max-width: 320px;

--- a/src/components/form/Input.js
+++ b/src/components/form/Input.js
@@ -6,7 +6,7 @@ import {
   GREY2,
   FONT_FAMILY,
   blue1,
-  LIGHT_RED,
+  PINK,
 } from '../../config/styles'
 
 const Label = styled.label`
@@ -30,7 +30,7 @@ export const ErrorMessage = styled.p`
   font-size: 0.77rem;
   padding: 0 8px;
   color: ${blue1()};
-  background-color: ${LIGHT_RED};
+  background-color: ${PINK};
   ${FONT_FAMILY};
   font-weight: bold;
   margin-bottom: 0;

--- a/src/components/navigation/menu/Menu.json
+++ b/src/components/navigation/menu/Menu.json
@@ -28,6 +28,10 @@
       {
         "to": "/react-redux-graphql-part-time-course",
         "text": "Part-time"
+      },
+      {
+        "to": "/graphql",
+        "text": "GraphQL"
       }
     ]
   },

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -5,8 +5,15 @@ import {
   REACT_BOOTCAMP,
   PART_TIME,
   ADVANCED_REACT,
+  GRAPHQL_BOOTCAMP,
 } from '../../config/data'
-import { GREY2, YELLOW, LIGHT_RED, REACT_BLUE_DARK } from '../../config/styles'
+import {
+  GREY2,
+  YELLOW,
+  GRAPHQL_PINK,
+  REACT_BLUE_DARK,
+  REACT_NATIVE_GREEN,
+} from '../../config/styles'
 
 export const SCREEN_XS_MAX = '767px'
 export const SCREEN_SM_MIN = '768px'
@@ -29,9 +36,11 @@ export const selectTypeColor = type => {
     case PART_TIME:
       return GREY2
     case REACT_NATIVE:
-      return LIGHT_RED
+      return REACT_NATIVE_GREEN
     case ADVANCED_REACT:
       return YELLOW
+    case GRAPHQL_BOOTCAMP:
+      return GRAPHQL_PINK
     default:
       return REACT_BLUE_DARK
   }

--- a/src/config/data.js
+++ b/src/config/data.js
@@ -19,6 +19,7 @@ export const REACT_NATIVE = 'React Native'
 export const PART_TIME = 'Part-time'
 export const REACT_BOOTCAMP = 'React bootcamp'
 export const ADVANCED_REACT = 'Advanced React'
+export const GRAPHQL_BOOTCAMP = 'GraphQL bootcamp'
 
 /*
 Boocamp prices:

--- a/src/config/images.js
+++ b/src/config/images.js
@@ -47,6 +47,9 @@ export const CURRICULUM_FULL_TRAINING_IMG =
 export const SMALL_CLASSROOM =
   'https://firebasestorage.googleapis.com/v0/b/reactjsacademy-react.appspot.com/o/classroom-small.jpg?alt=media'
 
+export const WHY_GQLU_ACADEMY =
+  'https://firebasestorage.googleapis.com/v0/b/reactjsacademy-react.appspot.com/o/graphql_university%2Fhomepage_whyGQLU.jpg?alt=media'
+
 export const HELLO_STUDENT =
   'https://firebasestorage.googleapis.com/v0/b/reactjsacademy-react.appspot.com/o/community_coachCommunity.jpg?alt=media'
 

--- a/src/config/styles.js
+++ b/src/config/styles.js
@@ -19,7 +19,12 @@ export const GREY2 = '#4a4a4a'
 export const WHITE = '#fff'
 
 export const RED = 'red'
-export const LIGHT_RED = '#f388a2'
+
+export const PINK = '#f388a2'
+
+export const GRAPHQL_PINK = '#ed7dc8'
+
+export const REACT_NATIVE_GREEN = '#80da8d'
 
 export const CALLTOACTIONRED = '#be6045'
 

--- a/src/pages/graphql.js
+++ b/src/pages/graphql.js
@@ -1,23 +1,20 @@
 import React from 'react'
-import { LinkButton } from '../components/buttons'
 import { Link } from '../components/navigation'
 import Section, { TopSection } from '../components/layout/Section'
 import Grid, { Col, Row } from '../components/layout/Grid'
-import { H2, P, Span } from '../components/text'
+import { H2, P } from '../components/text'
 import Ul, { Li } from '../components/layout/Ul'
 import { CurriculumGraphQL } from '../components/curriculum'
 import Header from '../components/layout/Header'
 import { HideComponentsUsingCss } from '../components/utils'
 import {
   TrustedBySection,
-  AttendeeQuote,
   UpcomingTrainingSection,
 } from '../components/training'
-import { Card, Video } from '../components/elements'
+import { Card } from '../components/elements'
 import CallToActionNextTrainings from '../components/layout/CallToActionNextTrainings'
 import { WHY_GQLU_ACADEMY, SMALL_CLASSROOM } from '../config/images.js'
 import {
-  CalendarIcon,
   CodeIcon,
   CollabsIcon,
   HeartIcon,
@@ -25,7 +22,6 @@ import {
   ProductionReadyIcon,
   SpannerIcon,
   StarIcon,
-  TimeIcon,
   TrainerIcon,
   BulletIcon,
 } from '../components/icons'
@@ -37,16 +33,6 @@ import {
   GRAPHQL_BOOTCAMP,
 } from '../config/data'
 import header from '../components/layout/Header.json'
-
-// const SectionButtonRow = styled(Row)`
-//   margin-top: 30px;
-//   @media (max-width: ${SCREEN_XS_MAX}) {
-//     a {
-//       margin-top: 5px;
-//       display: block;
-//     }
-//   }
-// `
 
 const trainings = selectTrainings(GRAPHQL_BOOTCAMP)
 const nextTraining = selectFirstTraining(GRAPHQL_BOOTCAMP)
@@ -71,7 +57,7 @@ const GraphQL = () => (
         <CallToActionNextTrainings left trainings={trainings} />
         <Card border="shadow">
           <Link to="#upcoming-courses" name="upcoming-courses" />
-          <CurriculumGraphQL />
+          <CurriculumGraphQL enableToggle isOpen={false} />
         </Card>
       </Grid>
     </TopSection>
@@ -94,29 +80,8 @@ const GraphQL = () => (
                 <BulletIcon icon={CollabsIcon} />A{' '}
                 <strong>collaborative</strong> learning environment.
               </Li>
-              {/* <Li>
-                    <BulletIcon icon={TimeIcon} />
-                    <Link to="/graphql-bootcamp-london">Bootcamps</Link> for
-                    accelerated learning.
-                  </Li>
-                  <Li>
-                    <BulletIcon icon={CalendarIcon} />
-                    <Link to="/react-redux-graphql-part-time-course">
-                      Part-time courses
-                    </Link>{' '}
-                    for accelerated learning.
-                  </Li> */}
             </Ul>
             <P />
-            {/* <SectionButtonRow>
-                  <Col sm={6}>
-                    <LinkButton
-                      cta
-                      to={trainingBootcamp.pathUrl}
-                      children="GraphQL Bootcamp"
-                    />
-                  </Col>
-                </SectionButtonRow> */}
           </Col>
           <HideComponentsUsingCss xs sm>
             <Col md={5} mdOffset={1}>
@@ -169,13 +134,6 @@ const GraphQL = () => (
                 <strong>Stay ahead</strong> in modern development.
               </Li>
             </Ul>
-            {/* <SectionButtonRow>
-                  <Col sm={6}>
-                    <LinkButton to="/#contact-us">
-                      Corporate training - Get in touch!
-                    </LinkButton>
-                  </Col>
-                </SectionButtonRow> */}
           </Col>
         </Row>
       </Grid>

--- a/src/pages/graphql.js
+++ b/src/pages/graphql.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import moment from 'moment'
 import { LinkButton } from '../components/buttons'
 import { Link } from '../components/navigation'
 import Section, { TopSection } from '../components/layout/Section'
@@ -8,6 +7,7 @@ import { H2, P, Span } from '../components/text'
 import Ul, { Li } from '../components/layout/Ul'
 import { CurriculumGraphQL } from '../components/curriculum'
 import Header from '../components/layout/Header'
+import { HideComponentsUsingCss } from '../components/utils'
 import {
   TrustedBySection,
   AttendeeQuote,
@@ -15,15 +15,21 @@ import {
 } from '../components/training'
 import { Card, Video } from '../components/elements'
 import CallToActionNextTrainings from '../components/layout/CallToActionNextTrainings'
-import { DAVIAN } from '../config/images'
+import { WHY_GQLU_ACADEMY, SMALL_CLASSROOM } from '../config/images.js'
 import {
-  NotBegginersIcon,
-  RunFastIcon,
-  TargetIcon,
-  TickBadgeIcon,
+  CalendarIcon,
+  CodeIcon,
+  CollabsIcon,
+  HeartIcon,
+  NotBegginerIcon,
+  ProductionReadyIcon,
+  SpannerIcon,
+  StarIcon,
+  TimeIcon,
+  TrainerIcon,
   BulletIcon,
-  PeopleNetWorkIcon,
 } from '../components/icons'
+import { Image } from '../components/elements'
 import { Breadcrumb } from '../components/navigation'
 import {
   selectTrainings,
@@ -31,6 +37,16 @@ import {
   GRAPHQL_BOOTCAMP,
 } from '../config/data'
 import header from '../components/layout/Header.json'
+
+// const SectionButtonRow = styled(Row)`
+//   margin-top: 30px;
+//   @media (max-width: ${SCREEN_XS_MAX}) {
+//     a {
+//       margin-top: 5px;
+//       display: block;
+//     }
+//   }
+// `
 
 const trainings = selectTrainings(GRAPHQL_BOOTCAMP)
 const nextTraining = selectFirstTraining(GRAPHQL_BOOTCAMP)
@@ -59,76 +75,112 @@ const GraphQL = () => (
         </Card>
       </Grid>
     </TopSection>
+
+    <Section>
+      <Grid>
+        <Row>
+          <Col md={5} mdOffset={1}>
+            <H2>Is GraphQL University right for me?</H2>
+            <Ul unstyled>
+              <Li>
+                <BulletIcon icon={NotBegginerIcon} />
+                For working developers - <strong>not for beginners!</strong>
+              </Li>
+              <Li>
+                <BulletIcon icon={SpannerIcon} />
+                <strong>Hands-on project-based</strong> training.
+              </Li>
+              <Li>
+                <BulletIcon icon={CollabsIcon} />A{' '}
+                <strong>collaborative</strong> learning environment.
+              </Li>
+              {/* <Li>
+                    <BulletIcon icon={TimeIcon} />
+                    <Link to="/graphql-bootcamp-london">Bootcamps</Link> for
+                    accelerated learning.
+                  </Li>
+                  <Li>
+                    <BulletIcon icon={CalendarIcon} />
+                    <Link to="/react-redux-graphql-part-time-course">
+                      Part-time courses
+                    </Link>{' '}
+                    for accelerated learning.
+                  </Li> */}
+            </Ul>
+            <P />
+            {/* <SectionButtonRow>
+                  <Col sm={6}>
+                    <LinkButton
+                      cta
+                      to={trainingBootcamp.pathUrl}
+                      children="GraphQL Bootcamp"
+                    />
+                  </Col>
+                </SectionButtonRow> */}
+          </Col>
+          <HideComponentsUsingCss xs sm>
+            <Col md={5} mdOffset={1}>
+              <Image
+                src={WHY_GQLU_ACADEMY}
+                width="100%"
+                alt="Female GraphQL University student wearing glasses concentrating whilst looking into the distance, surrounded by other students with a laptop in the near distance."
+              />
+            </Col>
+          </HideComponentsUsingCss>
+        </Row>
+      </Grid>
+    </Section>
+
     <Section>
       <Grid>
         <Row>
           <Col md={5}>
-            <Video youtubeId="6hmKu1-vW-8" />
-            <P>
-              Listen to Polina Stoyanova, a software engineer from tray.io who
-              attended our last bootcamp, on her experience at the bootcamp.
-            </P>
-            <Link to="https://www.youtube.com/channel/UC8eG6zOgWqeIZlJ8KRgEbSQ/videos">
-              Watch further testimonials
-            </Link>
-          </Col>
-          <Col md={5} mdOffset={1}>
-            <H2>
-              <Link to="#target-audience" name="target-audience" />
-              Is this React bootcamp right for me?
-            </H2>
-            <Ul unstyled>
-              <Li>
-                <BulletIcon icon={RunFastIcon} />
-                Extremely rapid, intense learning
-              </Li>
-              <Li>
-                <BulletIcon icon={NotBegginersIcon} />
-                Ideal for experienced programmers familiar with good practices.
-                Not for beginners!
-              </Li>
-              <Li>
-                <BulletIcon icon={TickBadgeIcon} />
-                Small classes with expert developer coaches - roughly one for
-                every four students
-              </Li>
-              <Li>
-                <BulletIcon icon={TargetIcon} />
-                Hands-on project-based training - most of the time you'll be
-                coding.
-              </Li>
-              <Li>
-                <BulletIcon icon={PeopleNetWorkIcon} />
-                Join a growing network of alumni for advice, knowledge and
-                social fun!
-              </Li>
-            </Ul>
-            <P>
-              <LinkButton cta to={nextTraining.pathUrl}>
-                Next bootcamp:{' '}
-                {moment(nextTraining.dateStartsOn).format('D MMM')},{' '}
-                {nextTraining.city}
-              </LinkButton>
-            </P>
-          </Col>
-        </Row>
-      </Grid>
-    </Section>
-    <Section>
-      <Grid>
-        <Row>
-          <Col lg={10} lgOffset={1}>
-            <AttendeeQuote
-              quote="After the bootcamp, I felt very very confident. You understand how to use React, how to build components from scratch and then into complex applications. Don’t be afraid - book as quickly as possible!"
-              fullname="Davian Robinson"
-              job="Senior Software Engineer"
-              company="ETZ Payments"
-              profilePicUrl={DAVIAN}
+            <Image
+              src={SMALL_CLASSROOM}
+              width="100%"
+              alt="Four developers gathered around a laptop, pair programming together on a piece of work during a GraphQL University bootcamp."
             />
           </Col>
+          <Col md={5} mdOffset={1}>
+            <H2>Why GraphQL University is great for your developers</H2>
+            <Ul unstyled>
+              <Li>
+                <BulletIcon icon={ProductionReadyIcon} />
+                <strong>Build production ready</strong> apps leverging graphQL.
+              </Li>
+              <Li>
+                <BulletIcon icon={CollabsIcon} />
+                Discuss <strong>real-world projects</strong>.
+              </Li>
+              <Li>
+                <BulletIcon icon={StarIcon} />
+                Learn <strong>best practices</strong>.
+              </Li>
+              <Li>
+                <BulletIcon icon={TrainerIcon} />
+                <strong>Mentoring</strong> by our expert coaches.
+              </Li>
+              <Li>
+                <BulletIcon icon={HeartIcon} />
+                Alumni <strong>community</strong>.
+              </Li>
+              <Li>
+                <BulletIcon icon={CodeIcon} />
+                <strong>Stay ahead</strong> in modern development.
+              </Li>
+            </Ul>
+            {/* <SectionButtonRow>
+                  <Col sm={6}>
+                    <LinkButton to="/#contact-us">
+                      Corporate training - Get in touch!
+                    </LinkButton>
+                  </Col>
+                </SectionButtonRow> */}
+          </Col>
         </Row>
       </Grid>
     </Section>
+
     <TrustedBySection />
     <UpcomingTrainingSection />
   </React.Fragment>

--- a/src/pages/graphql.js
+++ b/src/pages/graphql.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Link } from '../components/navigation'
 import Section, { TopSection } from '../components/layout/Section'
 import Grid, { Col, Row } from '../components/layout/Grid'
-import { H2, P } from '../components/text'
+import { H2, P, H2Ref } from '../components/text'
 import Ul, { Li } from '../components/layout/Ul'
 import { CurriculumGraphQL } from '../components/curriculum'
 import Header from '../components/layout/Header'
@@ -66,7 +66,12 @@ const GraphQL = () => (
       <Grid>
         <Row>
           <Col md={5} mdOffset={1}>
-            <H2>Is GraphQL University right for me?</H2>
+            <H2Ref>
+              Is ReactJS Academy's GraphQL course right for me?
+              <Link to="#target-audience" name="target-audience">
+                #
+              </Link>
+            </H2Ref>
             <Ul unstyled>
               <Li>
                 <BulletIcon icon={NotBegginerIcon} />
@@ -88,7 +93,7 @@ const GraphQL = () => (
               <Image
                 src={WHY_GQLU_ACADEMY}
                 width="100%"
-                alt="Female GraphQL University student wearing glasses concentrating whilst looking into the distance, surrounded by other students with a laptop in the near distance."
+                alt="Female GraphQL course student wearing glasses concentrating whilst looking into the distance, surrounded by other students with a laptop in the near distance."
               />
             </Col>
           </HideComponentsUsingCss>
@@ -103,15 +108,15 @@ const GraphQL = () => (
             <Image
               src={SMALL_CLASSROOM}
               width="100%"
-              alt="Four developers gathered around a laptop, pair programming together on a piece of work during a GraphQL University bootcamp."
+              alt="Four developers gathered around a laptop, pair programming together on a piece of work during a GraphQL bootcamp."
             />
           </Col>
           <Col md={5} mdOffset={1}>
-            <H2>Why GraphQL University is great for your developers</H2>
+            <H2>Why our GraphQL course is great for your developers</H2>
             <Ul unstyled>
               <Li>
                 <BulletIcon icon={ProductionReadyIcon} />
-                <strong>Build production ready</strong> apps leverging graphQL.
+                <strong>Build production ready</strong> apps leverging GraphQL.
               </Li>
               <Li>
                 <BulletIcon icon={CollabsIcon} />

--- a/src/pages/graphql.js
+++ b/src/pages/graphql.js
@@ -61,7 +61,7 @@ const GraphQL = () => (
             <LinkButton
               cta
               to="#contact-us"
-              children="Contact us to find out more >>"
+              children="Interested? Contact us >>"
             />
           </Col>
         </CallToActionRow>

--- a/src/pages/graphql.js
+++ b/src/pages/graphql.js
@@ -6,7 +6,7 @@ import Section, { TopSection } from '../components/layout/Section'
 import Grid, { Col, Row } from '../components/layout/Grid'
 import { H2, P, Span } from '../components/text'
 import Ul, { Li } from '../components/layout/Ul'
-import { CurriculumBootcamp } from '../components/curriculum'
+import { CurriculumGraphQL } from '../components/curriculum'
 import Header from '../components/layout/Header'
 import {
   TrustedBySection,
@@ -55,7 +55,7 @@ const GraphQL = () => (
         <CallToActionNextTrainings left trainings={trainings} />
         <Card border="shadow">
           <Link to="#upcoming-courses" name="upcoming-courses" />
-          <CurriculumBootcamp />
+          <CurriculumGraphQL />
         </Card>
       </Grid>
     </TopSection>

--- a/src/pages/graphql.js
+++ b/src/pages/graphql.js
@@ -1,0 +1,137 @@
+import React from 'react'
+import moment from 'moment'
+import { LinkButton } from '../components/buttons'
+import { Link } from '../components/navigation'
+import Section, { TopSection } from '../components/layout/Section'
+import Grid, { Col, Row } from '../components/layout/Grid'
+import { H2, P, Span } from '../components/text'
+import Ul, { Li } from '../components/layout/Ul'
+import { CurriculumBootcamp } from '../components/curriculum'
+import Header from '../components/layout/Header'
+import {
+  TrustedBySection,
+  AttendeeQuote,
+  UpcomingTrainingSection,
+} from '../components/training'
+import { Card, Video } from '../components/elements'
+import CallToActionNextTrainings from '../components/layout/CallToActionNextTrainings'
+import { DAVIAN } from '../config/images'
+import {
+  NotBegginersIcon,
+  RunFastIcon,
+  TargetIcon,
+  TickBadgeIcon,
+  BulletIcon,
+  PeopleNetWorkIcon,
+} from '../components/icons'
+import { Breadcrumb } from '../components/navigation'
+import {
+  selectTrainings,
+  selectFirstTraining,
+  GRAPHQL_BOOTCAMP,
+} from '../config/data'
+import header from '../components/layout/Header.json'
+
+const trainings = selectTrainings(GRAPHQL_BOOTCAMP)
+const nextTraining = selectFirstTraining(GRAPHQL_BOOTCAMP)
+
+const GraphQL = () => (
+  <React.Fragment>
+    <Breadcrumb
+      path={[
+        { to: '/', label: 'Home' },
+        { to: '/graphql', label: 'GraphQL bootcamp' },
+      ]}
+    />
+    <Header
+      titleLines={['Take your dev career further', 'by mastering GraphQL']}
+      subtitle="In-person development training from industry experts"
+      bgImg="full-time"
+      links={header.landingPageLinks.links}
+      type={GRAPHQL_BOOTCAMP}
+    />
+    <TopSection>
+      <Grid>
+        <CallToActionNextTrainings left trainings={trainings} />
+        <Card border="shadow">
+          <Link to="#upcoming-courses" name="upcoming-courses" />
+          <CurriculumBootcamp />
+        </Card>
+      </Grid>
+    </TopSection>
+    <Section>
+      <Grid>
+        <Row>
+          <Col md={5}>
+            <Video youtubeId="6hmKu1-vW-8" />
+            <P>
+              Listen to Polina Stoyanova, a software engineer from tray.io who
+              attended our last bootcamp, on her experience at the bootcamp.
+            </P>
+            <Link to="https://www.youtube.com/channel/UC8eG6zOgWqeIZlJ8KRgEbSQ/videos">
+              Watch further testimonials
+            </Link>
+          </Col>
+          <Col md={5} mdOffset={1}>
+            <H2>
+              <Link to="#target-audience" name="target-audience" />
+              Is this React bootcamp right for me?
+            </H2>
+            <Ul unstyled>
+              <Li>
+                <BulletIcon icon={RunFastIcon} />
+                Extremely rapid, intense learning
+              </Li>
+              <Li>
+                <BulletIcon icon={NotBegginersIcon} />
+                Ideal for experienced programmers familiar with good practices.
+                Not for beginners!
+              </Li>
+              <Li>
+                <BulletIcon icon={TickBadgeIcon} />
+                Small classes with expert developer coaches - roughly one for
+                every four students
+              </Li>
+              <Li>
+                <BulletIcon icon={TargetIcon} />
+                Hands-on project-based training - most of the time you'll be
+                coding.
+              </Li>
+              <Li>
+                <BulletIcon icon={PeopleNetWorkIcon} />
+                Join a growing network of alumni for advice, knowledge and
+                social fun!
+              </Li>
+            </Ul>
+            <P>
+              <LinkButton cta to={nextTraining.pathUrl}>
+                Next bootcamp:{' '}
+                {moment(nextTraining.dateStartsOn).format('D MMM')},{' '}
+                {nextTraining.city}
+              </LinkButton>
+            </P>
+          </Col>
+        </Row>
+      </Grid>
+    </Section>
+    <Section>
+      <Grid>
+        <Row>
+          <Col lg={10} lgOffset={1}>
+            <AttendeeQuote
+              quote="After the bootcamp, I felt very very confident. You understand how to use React, how to build components from scratch and then into complex applications. Don’t be afraid - book as quickly as possible!"
+              fullname="Davian Robinson"
+              job="Senior Software Engineer"
+              company="ETZ Payments"
+              profilePicUrl={DAVIAN}
+            />
+          </Col>
+        </Row>
+      </Grid>
+    </Section>
+    <TrustedBySection />
+    <UpcomingTrainingSection />
+  </React.Fragment>
+)
+
+export default GraphQL

--- a/src/pages/graphql.js
+++ b/src/pages/graphql.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import { Link } from '../components/navigation'
+import { LinkButton } from '../components/buttons'
 import Section, { TopSection } from '../components/layout/Section'
 import Grid, { Col, Row } from '../components/layout/Grid'
 import { H2, P, H2Ref } from '../components/text'
 import Ul, { Li } from '../components/layout/Ul'
 import { CurriculumGraphQL } from '../components/curriculum'
 import Header from '../components/layout/Header'
+import { CallToActionRow } from '../components/layout/CallToActionNextTrainings'
 import { HideComponentsUsingCss } from '../components/utils'
 import {
   TrustedBySection,
@@ -54,7 +56,16 @@ const GraphQL = () => (
     />
     <TopSection>
       <Grid>
-        <CallToActionNextTrainings left trainings={trainings} />
+        <CallToActionRow left>
+          <Col xs={12} mdOffset={1} md={5}>
+            <LinkButton
+              cta
+              to="#contact-us"
+              children="Contact us to find out more >>"
+            />
+          </Col>
+        </CallToActionRow>
+        {/* <CallToActionNextTrainings left trainings={trainings} /> */}
         <Card border="shadow">
           <Link to="#upcoming-courses" name="upcoming-courses" />
           <CurriculumGraphQL enableToggle isOpen={false} />


### PR DESCRIPTION
This is the mvp implementation of adding graphql to RJSA course offerings. The aim of this mvp is to have a graphql page as a subdomain in order to measure how many people are going there and prove that wether changing the brand name is a good idea at this time. 

This will also allow us to add instances on the site for GraphQL trainings. 

@shakersinthedark is setting up GTM on the key CTA's for the page, plus heat maps on hotjar for this page  in order to record user interaction. 